### PR TITLE
Fix broken link to 18F's Open Source practices.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the open source policy of [NYC Planning Labs](https://p
 
 This policy was forked from [18F's policy](https://github.com/18F/open-source-policy), which was forked from the [Consumer Financial Protection Bureau's policy](https://github.com/cfpb/source-code-policy). 18F has guidance on how their team puts this policy into practice. 
 
-**[Read 18F's open source team practices.](practice.md)**
+**[Read 18F's open source team practices.](https://github.com/18F/open-source-policy/blob/master/practice.md)**
 
 ### Public domain
 


### PR DESCRIPTION
There was a reference to a `policy.md` file that looks like was removed at some point after forking from 18F.  This PR just fixes that broken link to point back to 18F's original practices document, fixing a 404.